### PR TITLE
Add a leading slash to ensure the SW gets registered at the site root

### DIFF
--- a/service-worker-registration.js
+++ b/service-worker-registration.js
@@ -22,7 +22,7 @@ if ('serviceWorker' in navigator) {
   // It won't be able to control pages unless it's located at the same level or higher than them.
   // *Don't* register service worker file in, e.g., a scripts/ sub-directory!
   // See https://github.com/slightlyoff/ServiceWorker/issues/468
-  navigator.serviceWorker.register('service-worker.js').then(function(reg) {
+  navigator.serviceWorker.register('/service-worker.js').then(function(reg) {
     // updatefound is fired if service-worker.js changes.
     reg.onupdatefound = function() {
       // The updatefound event implies that reg.installing is set; see


### PR DESCRIPTION
Without a leading slash, the service worker registration URL is relative to the current page, rather than to the site root. [source](https://github.com/w3c/ServiceWorker/issues/1001#issuecomment-258487310)

This causes a problem when visiting a sub-page such as `example.com/some/path` as the SW tries to register at `example.com/some/service-worker.js`

As service workers should be registered at the site root, hopefully this change should be right for everyone. 

Thanks for this module - I was up and running in minutes! :)